### PR TITLE
Fix Python error handling under strict shell options

### DIFF
--- a/run_enhanced_valis_registration.sh
+++ b/run_enhanced_valis_registration.sh
@@ -272,15 +272,12 @@ echo "  H&amp;E Slide: $HE_SLIDE_PATH"
 echo "  Output Dir: $OUTPUT_DIR"
 echo "  H&amp;E Downsample Factor for Reg: $DEFAULT_HE_DOWNSAMPLE_FACTOR"
 
-python "$PYTHON_SCRIPT_PATH" \
+if ! python "$PYTHON_SCRIPT_PATH" \
     --cd8_slide "$CD8_SLIDE_PATH" \
     --he_slide "$HE_SLIDE_PATH" \
     --output_dir "$OUTPUT_DIR" \
-    --he_downsample_factor "$DEFAULT_HE_DOWNSAMPLE_FACTOR"
-
-PYTHON_EXIT_CODE=$?
-if [ $PYTHON_EXIT_CODE -ne 0 ]; then
-    error_exit "Python registration script failed with exit code $PYTHON_EXIT_CODE."
+    --he_downsample_factor "$DEFAULT_HE_DOWNSAMPLE_FACTOR"; then
+    error_exit "Python registration script failed with an error."
 fi
 
 echo "-----------------------------------------------------------------------------"

--- a/wsi_registration.sh
+++ b/wsi_registration.sh
@@ -80,10 +80,7 @@ echo "Output Directory: $OUTPUT_DIR"
 
 # Run the registration script
 echo "Executing VALIS registration..."
-python "$PYTHON_SCRIPT" --cd8_slide "$CD8_SLIDE" --he_slide "$HE_SLIDE" --output_dir "$OUTPUT_DIR"
-
-# Check the exit code of the Python script
-if [ $? -ne 0 ]; then
+if ! python "$PYTHON_SCRIPT" --cd8_slide "$CD8_SLIDE" --he_slide "$HE_SLIDE" --output_dir "$OUTPUT_DIR"; then
     error_exit "Registration process failed with an error."
 fi
 


### PR DESCRIPTION
## Summary
- avoid exiting automatically when Python registration fails
- run Python with explicit conditional in `wsi_registration.sh`
- run Python with explicit conditional in `run_enhanced_valis_registration.sh`

## Testing
- `bash -n wsi_registration.sh`
- `bash -n run_enhanced_valis_registration.sh` *(fails: syntax error, requires zsh)*