### PR TITLE
Implement evaluation metrics output

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This script requires the `zsh` shell and the `valis_env` conda environment to be
 The registration process will create the following in your output directory:
 
 - `registration_results/`: Directory containing the registered slides
-- `registration_evaluation/`: Directory containing evaluation metrics
+- `registration_evaluation/`: Directory containing evaluation metrics (a `metrics.json` file summarizing the run)
 
 ## How It Works
 

--- a/wsi_registration.sh
+++ b/wsi_registration.sh
@@ -78,15 +78,15 @@ echo "CD8 Slide: $CD8_SLIDE"
 echo "HE Slide: $HE_SLIDE"
 echo "Output Directory: $OUTPUT_DIR"
 
-# Run the registration script
-echo "Executing VALIS registration..."
-if ! python "$PYTHON_SCRIPT" --cd8_slide "$CD8_SLIDE" --he_slide "$HE_SLIDE" --output_dir "$OUTPUT_DIR"; then
-    error_exit "Registration process failed with an error."
-fi
-
 # Create evaluation directory
 EVAL_DIR="$OUTPUT_DIR/registration_evaluation"
 mkdir -p "$EVAL_DIR"
+
+# Run the registration script
+echo "Executing VALIS registration..."
+if ! python "$PYTHON_SCRIPT" --cd8_slide "$CD8_SLIDE" --he_slide "$HE_SLIDE" --output_dir "$OUTPUT_DIR" --eval_dir "$EVAL_DIR"; then
+    error_exit "Registration process failed with an error."
+fi
 
 # Check for success
 if [ -d "$OUTPUT_DIR/registration_results" ]; then


### PR DESCRIPTION
## Summary
- save runtime metrics in `registration_evaluation/metrics.json`
- pass evaluation directory from `wsi_registration.sh`
- note metrics file in README

## Testing
- `python -m py_compile slide_registration.py`
- `bash -n wsi_registration.sh`
