### PR TITLE
Remove trailing spaces and add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.py]
+charset = utf-8
+
+[*.sh]
+charset = utf-8

--- a/run_enhanced_valis_registration.sh
+++ b/run_enhanced_valis_registration.sh
@@ -4,7 +4,7 @@
 # Enhanced WSI Registration Shell Script using VALIS
 # =============================================================================
 #
-# This script automates an enhanced registration of CD8 (reference) and 
+# This script automates an enhanced registration of CD8 (reference) and
 # H&E (secondary, downsampled) Whole Slide Images using VALIS.
 # It generates and executes a Python script to perform:
 #   1. H&E slide downsampling by a specified factor for registration.
@@ -30,7 +30,7 @@ set -euo pipefail
 # --- Configuration ---
 CONDA_ENV_NAME="valis_env"
 # Default H&E downsample factor for registration processing (2 means 2x coarser)
-DEFAULT_HE_DOWNSAMPLE_FACTOR=2 
+DEFAULT_HE_DOWNSAMPLE_FACTOR=2
 
 
 # --- Helper Functions ---
@@ -143,7 +143,7 @@ def determine_he_level(he_slide_path_py, he_downsample_factor_py):
     """
     if he_downsample_factor_py <= 1:
         return 0 # Full resolution
-    
+
     # Simplistic: 2x -> level 1, 3x or 4x -> level 2. This needs to match slide structure.
     # For a 2x downsample, level 1 is often appropriate.
     if he_downsample_factor_py == 2:
@@ -173,8 +173,8 @@ def perform_registration(cd8_slide_py, he_slide_py, output_dir_py, he_downsample
 
     # Determine the H&E slide loading arguments for downsampling
     he_target_level = determine_he_level(he_slide_py, he_downsample_factor_py)
-    
-    # slide_loading_kwargs: First item for cd8_slide (reference, default loading), 
+
+    # slide_loading_kwargs: First item for cd8_slide (reference, default loading),
     #                       Second item for he_slide (secondary, with specific level)
     slide_kwargs_list = [
         {},  # Default for CD8 slide
@@ -184,7 +184,7 @@ def perform_registration(cd8_slide_py, he_slide_py, output_dir_py, he_downsample
 
     try:
         registration_start_time = time.time()
-        
+
         # Initialize VALIS registrar
         # CD8 slide (first in list) will be the reference by default if ref_img_f is not set
         # or if align_to_reference is False.
@@ -204,18 +204,18 @@ def perform_registration(cd8_slide_py, he_slide_py, output_dir_py, he_downsample
         print("Python: MACRO-registration completed.")
 
         print("Python: Starting MICRO-registration (fine-tuning alignment)...")
-        # VALIS API for micro-registration might vary. 
+        # VALIS API for micro-registration might vary.
         # Simpler versions might just be `registrar.register_micro()`.
         # More explicit versions might take slide objects.
         # Assuming `registrar.register_micro()` uses the current state of the registrar.
-        registrar.register_micro() 
+        registrar.register_micro()
         print("Python: MICRO-registration completed.")
 
         print(f"Python: Warping and saving registered slides to {output_dir_py} at FULL RESOLUTION (level 0)...")
         # crop="overlap" ensures the maximum shared area is warped.
         # level=0 specifies full resolution for the output.
         registrar.warp_and_save_slides(slide_dst_dir=output_dir_py, crop="overlap", level=0)
-        
+
         registration_elapsed_time = time.time() - registration_start_time
         print(f"Python: VALIS registration and warping completed in {registration_elapsed_time:.2f} seconds.")
         print(f"Python: All results, including warped slides, saved in: {output_dir_py}")
@@ -240,7 +240,7 @@ def perform_registration(cd8_slide_py, he_slide_py, output_dir_py, he_downsample
             except Exception as e_jvm_final:
                 print(f"Python: Error during final JVM cleanup: {e_jvm_final}", file=sys.stderr)
                 # Log but don't make the script fail here if main part succeeded
-    
+
     sys.exit(0) # Explicitly exit with success
 
 
@@ -249,14 +249,14 @@ if __name__ == "__main__":
     parser_py.add_argument("--cd8_slide", required=True, help="Path to CD8 slide (reference)")
     parser_py.add_argument("--he_slide", required=True, help="Path to H&E slide (secondary)")
     parser_py.add_argument("--output_dir", required=True, help="Path to output directory for results")
-    parser_py.add_argument("--he_downsample_factor", type=int, required=True, 
+    parser_py.add_argument("--he_downsample_factor", type=int, required=True,
                            help="Factor by which H&E slide's resolution is reduced for registration processing (e.g., 2 for 2x).")
-    
+
     args_py = parser_py.parse_args()
-    
+
     perform_registration(
-        args_py.cd8_slide, 
-        args_py.he_slide, 
+        args_py.cd8_slide,
+        args_py.he_slide,
         args_py.output_dir,
         args_py.he_downsample_factor
     )

--- a/slide_registration.py
+++ b/slide_registration.py
@@ -78,15 +78,15 @@ def main():
     # Warp and save the registered slides to the output directory
     print(f"Warping and saving aligned slides to: {results_dir}")
     registrar.warp_and_save_slides(results_dir, crop="overlap")
-    
+
     # Clean up the JVM as recommended
     print("Cleaning up resources...")
     registration.kill_jvm()
-    
+
     elapsed_time = time.time() - start_time
     print(f"Registration completed in {elapsed_time:.2f} seconds")
     print(f"Results saved to: {results_dir}")
-    
+
     # Return success status for shell script
     return 0
 

--- a/validate_registration.py
+++ b/validate_registration.py
@@ -33,7 +33,7 @@ def extract_tile(slide, x, y, size=512):
         if x < 0 or y < 0 or x + size > slide.shape[1] or y + size > slide.shape[0]:
             print(f"Invalid coordinates: ({x}, {y}) with size {size} for slide shape {slide.shape}")
             return None
-        
+
         # Extract the tile
         tile = slide[y:y+size, x:x+size]
         return tile
@@ -44,37 +44,37 @@ def extract_tile(slide, x, y, size=512):
 def calculate_metrics(tile1, tile2):
     """Calculate registration quality metrics between two tiles"""
     results = {}
-    
+
     # Convert to grayscale if multi-channel
     if len(tile1.shape) > 2 and tile1.shape[2] > 1:
         gray1 = np.mean(tile1, axis=2).astype(np.uint8)
     else:
         gray1 = tile1.astype(np.uint8)
-        
+
     if len(tile2.shape) > 2 and tile2.shape[2] > 1:
         gray2 = np.mean(tile2, axis=2).astype(np.uint8)
     else:
         gray2 = tile2.astype(np.uint8)
-    
+
     # Normalize for better comparison
     gray1 = exposure.rescale_intensity(gray1)
     gray2 = exposure.rescale_intensity(gray2)
-    
+
     try:
         # Calculate SSIM (higher is better, max 1.0)
         ssim_value = ssim(gray1, gray2, data_range=gray2.max() - gray2.min())
         results['ssim'] = ssim_value
-        
+
         # Calculate MSE (lower is better)
         mse_value = mean_squared_error(gray1, gray2)
         results['mse'] = mse_value
-        
+
         # Calculate normalized cross-correlation (higher is better, max 1.0)
         norm1 = gray1 - np.mean(gray1)
         norm2 = gray2 - np.mean(gray2)
         correlation = np.sum(norm1 * norm2) / (np.sqrt(np.sum(norm1**2)) * np.sqrt(np.sum(norm2**2)))
         results['correlation'] = correlation
-        
+
         return results
     except Exception as e:
         print(f"Error calculating metrics: {e}")
@@ -83,17 +83,17 @@ def calculate_metrics(tile1, tile2):
 def visualize_tiles(tile1, tile2, he_name, cd8_name, coords, metrics, output_path=None):
     """Visualize the side-by-side comparison of tiles with metrics"""
     fig, axes = plt.subplots(1, 3, figsize=(15, 5))
-    
+
     # Display H&E tile
     axes[0].imshow(tile1)
     axes[0].set_title(f"{he_name}\n({coords[0]}, {coords[1]})")
     axes[0].axis('off')
-    
+
     # Display CD8 tile
     axes[1].imshow(tile2)
     axes[1].set_title(f"{cd8_name}\n({coords[0]}, {coords[1]})")
     axes[1].axis('off')
-    
+
     # Create overlay to show registration accuracy
     if len(tile1.shape) == 3 and tile1.shape[2] == 3 and len(tile2.shape) == 2:
         # If H&E is RGB and CD8 is grayscale, create a combined image
@@ -115,16 +115,16 @@ def visualize_tiles(tile1, tile2, he_name, cd8_name, coords, metrics, output_pat
         else:
             tile1_rgb = tile1
             tile2_rgb = tile2
-            
+
         # Create a simple overlay
         overlay = (0.5 * tile1_rgb + 0.5 * tile2_rgb).astype(np.uint8)
-    
+
     axes[2].imshow(overlay)
     axes[2].set_title(f"Overlay\nSSIM: {metrics['ssim']:.3f}, Corr: {metrics['correlation']:.3f}")
     axes[2].axis('off')
-    
+
     plt.tight_layout()
-    
+
     # Add metrics as text
     metrics_text = (
         f"Registration Metrics:\n"
@@ -132,14 +132,14 @@ def visualize_tiles(tile1, tile2, he_name, cd8_name, coords, metrics, output_pat
         f"MSE: {metrics['mse']:.4f} (lower is better)\n"
         f"Correlation: {metrics['correlation']:.4f} (higher is better, max 1.0)"
     )
-    plt.figtext(0.5, 0.01, metrics_text, ha='center', fontsize=10, 
+    plt.figtext(0.5, 0.01, metrics_text, ha='center', fontsize=10,
                 bbox={"facecolor":"white", "alpha":0.8, "pad":5})
-    
+
     # Save if output path is provided
     if output_path:
         plt.savefig(output_path, dpi=300, bbox_inches='tight')
         print(f"Saved visualization to {output_path}")
-    
+
     plt.close()
 
 def main():
@@ -147,43 +147,43 @@ def main():
     registration_dir = "/Users/sashurameshbabu/WSI slides/registration_results/registered_slides"
     he_path = os.path.join(registration_dir, "HE_downsampled_x2.ome.tiff")
     cd8_path = os.path.join(registration_dir, "CD8_channel2.ome.tiff")
-    
+
     # Create output directory for visualizations
     output_dir = os.path.join(os.path.dirname(registration_dir), "validation_results")
     os.makedirs(output_dir, exist_ok=True)
-    
+
     # Load slides
     he_slide = load_slide(he_path)
     cd8_slide = load_slide(cd8_path)
-    
+
     if he_slide is None or cd8_slide is None:
         print("Failed to load one or both slides. Exiting.")
         sys.exit(1)
-    
+
     # Print slide information
     print("\nSlide Information:")
     print(f"H&E Slide: {he_slide.shape}")
     print(f"CD8 Slide: {cd8_slide.shape}")
-    
+
     # Check if slides have the same dimensions
     if he_slide.shape[:2] != cd8_slide.shape[:2]:
         print("Warning: Slides have different dimensions. Registration may not be valid.")
         print(f"  H&E shape: {he_slide.shape[:2]}")
         print(f"  CD8 shape: {cd8_slide.shape[:2]}")
-    
+
     # Define tile size
     tile_size = 512
-    
+
     # Define sample coordinates to extract (can be adjusted based on slide size)
     # We'll extract from top-left, center, and bottom-right
     height, width = min(he_slide.shape[0], cd8_slide.shape[0]), min(he_slide.shape[1], cd8_slide.shape[1])
-    
+
     coordinates = [
         (width // 4, height // 4),               # Top-left region
         (width // 2, height // 2),               # Center region
         (3 * width // 4, 3 * height // 4)        # Bottom-right region
     ]
-    
+
     # Create PDF for combined output
     pdf_path = os.path.join(output_dir, "registration_validation.pdf")
     with PdfPages(pdf_path) as pdf:
@@ -191,48 +191,48 @@ def main():
         all_metrics = []
         for i, (x, y) in enumerate(coordinates):
             print(f"\nExtracting tile {i+1} at coordinates ({x}, {y})")
-            
+
             # Extract tiles
             he_tile = extract_tile(he_slide, x, y, tile_size)
             cd8_tile = extract_tile(cd8_slide, x, y, tile_size)
-            
+
             if he_tile is None or cd8_tile is None:
                 print(f"Skipping tile {i+1} due to extraction error")
                 continue
-            
+
             # Calculate metrics
             metrics = calculate_metrics(he_tile, cd8_tile)
             all_metrics.append(metrics)
-            
+
             print(f"Tile {i+1} metrics:")
             print(f"  SSIM: {metrics['ssim']:.4f} (higher is better, max 1.0)")
             print(f"  MSE: {metrics['mse']:.4f} (lower is better)")
             print(f"  Correlation: {metrics['correlation']:.4f} (higher is better, max 1.0)")
-            
+
             # Visualize and save individual comparison
             img_path = os.path.join(output_dir, f"tile_{i+1}_comparison.png")
             visualize_tiles(he_tile, cd8_tile, "H&E", "CD8", (x, y), metrics, img_path)
-            
+
             # Also add to PDF
             plt.figure(figsize=(15, 5))
             visualize_tiles(he_tile, cd8_tile, "H&E", "CD8", (x, y), metrics)
             pdf.savefig(bbox_inches='tight')
             plt.close()
-        
+
         # Calculate and display overall metrics
         if all_metrics:
             avg_ssim = np.mean([m['ssim'] for m in all_metrics])
             avg_mse = np.mean([m['mse'] for m in all_metrics])
             avg_corr = np.mean([m['correlation'] for m in all_metrics])
-            
+
             print("\nOverall Registration Metrics (average across all tiles):")
             print(f"  Average SSIM: {avg_ssim:.4f}")
             print(f"  Average MSE: {avg_mse:.4f}")
             print(f"  Average Correlation: {avg_corr:.4f}")
-            
+
             # Add a summary page to the PDF
             plt.figure(figsize=(8, 6))
-            plt.text(0.5, 0.5, 
+            plt.text(0.5, 0.5,
                     f"Registration Validation Summary\n\n"
                     f"Number of tiles analyzed: {len(all_metrics)}\n\n"
                     f"Average SSIM: {avg_ssim:.4f}\n"
@@ -246,7 +246,7 @@ def main():
             plt.axis('off')
             pdf.savefig(bbox_inches='tight')
             plt.close()
-    
+
     print(f"\nValidation complete. Results saved to {output_dir}")
     print(f"PDF report saved to {pdf_path}")
 

--- a/visualize_registration.py
+++ b/visualize_registration.py
@@ -79,38 +79,38 @@ def load_registration_matrix():
     if matrix_path is None:
         print("Registration matrix file not found.")
         return np.eye(3)  # Return identity matrix as fallback
-    
+
     try:
         # Load the .npz file
         data = np.load(matrix_path)
-        
+
         # Display all keys in the file
         print(f"Keys in the registration matrix file: {list(data.keys())}")
-        
+
         # Try to find matrix with common names
         matrix_keys = ['matrix', 'registration_matrix', 'transform_matrix', 'homography']
         matrix = None
-        
+
         for key in matrix_keys:
             if key in data:
                 matrix = data[key]
                 break
-        
+
         # If no known key found, use the first array
         if matrix is None and len(data.keys()) > 0:
             first_key = list(data.keys())[0]
             matrix = data[first_key]
             print(f"Using key '{first_key}' for matrix")
-        
+
         # If we still don't have a matrix, return identity
         if matrix is None:
             print("Could not find matrix in NPZ file. Using identity matrix.")
             return np.eye(3)
-        
+
         print("Registration matrix:")
         print(matrix)
         return matrix
-        
+
     except Exception as e:
         print(f"Error loading registration matrix: {e}")
         return np.eye(3)  # Return identity matrix on error
@@ -120,44 +120,44 @@ def find_matching_tile_pairs(he_dir, cd8_dir, limit=5):
     if he_dir is None or cd8_dir is None:
         print("Tile directories not found.")
         return []
-    
+
     try:
         # Get lists of all image files
         he_tiles = glob.glob(os.path.join(he_dir, "*.png")) + glob.glob(os.path.join(he_dir, "*.jpg"))
         cd8_tiles = glob.glob(os.path.join(cd8_dir, "*.png")) + glob.glob(os.path.join(cd8_dir, "*.jpg"))
-        
+
         print(f"Found {len(he_tiles)} HE tiles and {len(cd8_tiles)} CD8 tiles")
-        
+
         # Extract tile identifiers to match pairs
         matching_pairs = []
         he_ids = {}
-        
+
         # Extract identifiers from filenames (assuming common naming pattern)
         for he_path in he_tiles:
             filename = os.path.basename(he_path)
             # Try different identifier formats
             identifier = os.path.splitext(filename)[0]  # Without extension
             he_ids[identifier] = he_path
-        
+
         # Find matching CD8 tiles
         for cd8_path in cd8_tiles:
             filename = os.path.basename(cd8_path)
             identifier = os.path.splitext(filename)[0]
-            
+
             if identifier in he_ids:
                 matching_pairs.append((he_ids[identifier], cd8_path))
                 if len(matching_pairs) >= limit:
                     break
-        
+
         # If no matches found, try to match by index
         if not matching_pairs and he_tiles and cd8_tiles:
             print("No matching filenames found. Matching by index...")
             for i in range(min(limit, min(len(he_tiles), len(cd8_tiles)))):
                 matching_pairs.append((he_tiles[i], cd8_tiles[i]))
-        
+
         print(f"Found {len(matching_pairs)} matching tile pairs")
         return matching_pairs
-        
+
     except Exception as e:
         print(f"Error finding matching tile pairs: {e}")
         return []
@@ -168,39 +168,39 @@ def create_side_by_side_comparison(he_path, cd8_path, output_path, index):
         # Read images
         he_img = cv2.imread(he_path)
         cd8_img = cv2.imread(cd8_path)
-        
+
         if he_img is None or cd8_img is None:
             print(f"Error loading images for comparison {index}")
             return False
-        
+
         # Convert to RGB for matplotlib
         he_img_rgb = cv2.cvtColor(he_img, cv2.COLOR_BGR2RGB)
         cd8_img_rgb = cv2.cvtColor(cd8_img, cv2.COLOR_BGR2RGB)
-        
+
         # Create figure with side-by-side comparison
         fig = plt.figure(figsize=(12, 6))
         gs = GridSpec(1, 2, figure=fig)
-        
+
         ax1 = fig.add_subplot(gs[0, 0])
         ax1.imshow(he_img_rgb)
         ax1.set_title('H&E Tile')
         ax1.axis('off')
-        
+
         ax2 = fig.add_subplot(gs[0, 1])
         ax2.imshow(cd8_img_rgb)
         ax2.set_title('CD8 Tile')
         ax2.axis('off')
-        
+
         plt.suptitle(f'Tile Pair Comparison {index}')
         plt.tight_layout()
-        
+
         # Save figure
         plt.savefig(output_path, dpi=150, bbox_inches='tight')
         plt.close(fig)
-        
+
         print(f"Saved comparison {index} to {output_path}")
         return True
-        
+
     except Exception as e:
         print(f"Error creating side-by-side comparison {index}: {e}")
         return False
@@ -209,17 +209,17 @@ def main():
     """Main function to execute all visualization tasks."""
     # Load and display registration matrix
     matrix = load_registration_matrix()
-    
+
     # Find matching tile pairs
     matching_pairs = find_matching_tile_pairs(he_tiles_dir, cd8_tiles_dir)
-    
+
     # Create side-by-side comparisons
     successful_comparisons = 0
     for i, (he_path, cd8_path) in enumerate(matching_pairs):
         output_path = os.path.join(output_dir, f"tile_comparison_{i+1}.png")
         if create_side_by_side_comparison(he_path, cd8_path, output_path, i+1):
             successful_comparisons += 1
-    
+
     # Print summary
     print("\nSummary:")
     print("=" * 50)

--- a/wsi_registration.sh
+++ b/wsi_registration.sh
@@ -104,10 +104,10 @@ mkdir -p "$EVAL_DIR"
 if [ -d "$OUTPUT_DIR/registration_results" ]; then
     echo "Registration completed successfully!"
     echo "Results are available in: $OUTPUT_DIR"
-    
+
     # Deactivate conda environment
     conda deactivate
-    
+
     exit 0
 else
     error_exit "Registration process did not complete successfully."


### PR DESCRIPTION
## Summary
- remove trailing spaces in Python and shell scripts
- add a basic `.editorconfig` enforcing trimming of trailing whitespace

## Testing
- `grep -n "[[:blank:]]$" -n slide_registration.py | head`
