### PR TITLE
Add base_dir CLI argument for visualization tools

### DIFF
--- a/validate_registration.py
+++ b/validate_registration.py
@@ -11,9 +11,22 @@ from skimage.metrics import structural_similarity as ssim
 from skimage.metrics import mean_squared_error
 from skimage import exposure
 import warnings
+import argparse
 
 # Suppress warnings
 warnings.filterwarnings("ignore")
+
+def parse_arguments():
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Validate registration of VALIS output slides"
+    )
+    parser.add_argument(
+        "--base_dir",
+        required=True,
+        help="Directory containing registration results",
+    )
+    return parser.parse_args()
 
 def load_slide(filepath):
     """Load an OME-TIFF slide and return as numpy array"""
@@ -143,8 +156,9 @@ def visualize_tiles(tile1, tile2, he_name, cd8_name, coords, metrics, output_pat
     plt.close()
 
 def main():
+    args = parse_arguments()
     # Define paths
-    registration_dir = "/Users/sashurameshbabu/WSI slides/registration_results/registered_slides"
+    registration_dir = os.path.join(args.base_dir, "registration_results", "registered_slides")
     he_path = os.path.join(registration_dir, "HE_downsampled_x2.ome.tiff")
     cd8_path = os.path.join(registration_dir, "CD8_channel2.ome.tiff")
     

--- a/visualize_registration.py
+++ b/visualize_registration.py
@@ -7,22 +7,34 @@ from PIL import Image
 import cv2
 import glob
 import random
+import argparse
 
 # Activate the correct environment if needed
 # Use conda environment as per user memory
 import sys
+
 print(f"Using Python: {sys.executable}")
 print(f"Python version: {sys.version}")
 
-# Set base directories - these should be adjusted based on the actual paths
-BASE_DIR = os.path.expanduser("~/WSI slides")
+def parse_arguments():
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Visualize results from VALIS registration"
+    )
+    parser.add_argument(
+        "--base_dir",
+        required=True,
+        help="Directory containing registration results",
+    )
+    return parser.parse_args()
+
+# Parse arguments and set base directory
+args = parse_arguments()
+BASE_DIR = args.base_dir
+
 if not os.path.exists(BASE_DIR):
-    # Try without space in name
-    BASE_DIR = os.path.expanduser("~/WSI_slides")
-    if not os.path.exists(BASE_DIR):
-        print("Could not find WSI slides directory. Please adjust the BASE_DIR in the script.")
-        BASE_DIR = os.path.expanduser("~")
-        print(f"Using home directory instead: {BASE_DIR}")
+    print(f"Base directory '{BASE_DIR}' does not exist.")
+    sys.exit(1)
 
 # Define paths (will try multiple potential locations)
 potential_matrix_paths = [


### PR DESCRIPTION
## Summary
- update `visualize_registration.py` to accept `--base_dir` for locating results
- add similar `--base_dir` option in `validate_registration.py`
- remove user specific fallback paths

## Testing
- `python -m py_compile visualize_registration.py validate_registration.py slide_registration.py visualize_tile_pairs.py`